### PR TITLE
Refactor Qt log window

### DIFF
--- a/geoAssembler/geometry.py
+++ b/geoAssembler/geometry.py
@@ -199,6 +199,7 @@ class GeometryAssembler:
 
 class AGIPDGeometry(GeometryAssembler):
     """Detector layout for AGIPD-1M."""
+    detector_name = 'AGIPD'
 
     def __init__(self, kd_geom):
         """Set the properties for AGIPD detector.
@@ -211,12 +212,11 @@ class AGIPDGeometry(GeometryAssembler):
         self.pixel_size = 2e-4  # 2e-4 metres == 0.2 mm
         self.frag_ss_pixels = 64
         self.frag_fs_pixels = 128
-        self.detector_name = 'AGIPD'
 
     @classmethod
     def from_quad_positions(cls, quad_pos=None):
         """Generate geometry from quadrant positions."""
-        quad_pos = quad_pos or Defaults.fallback_quad_pos[self.detector_name]
+        quad_pos = quad_pos or Defaults.fallback_quad_pos[cls.detector_name]
         kd_geom = AGIPD_1MGeometry.from_quad_positions(quad_pos)
         return cls(kd_geom)
 

--- a/geoAssembler/geometry.py
+++ b/geoAssembler/geometry.py
@@ -1,7 +1,6 @@
 """Provide AGIPD-D geometry information that supports quadrant moving."""
 
 import logging
-import os
 import tempfile
 
 import h5py
@@ -10,8 +9,6 @@ from karabo_data.geometry2 import (AGIPD_1MGeometry,
                                    LPD_1MGeometry, GeometryFragment)
 import numpy as np
 import pandas as pd
-
-from . import __version__
 
 from .defaults import DefaultGeometryConfig as Defaults
 

--- a/geoAssembler/gui_utils.py
+++ b/geoAssembler/gui_utils.py
@@ -44,7 +44,7 @@ def write_geometry(geom, filename, logger):
     Parameters:
         geom (GeometryAssembler): object holding the geometry information
         filename (str): Output filename
-        logger (str): Logging object to display information
+        logger (logging.Logger): Logging object to display information
     """
     from .geometry import AGIPDGeometry, DSSCGeometry, LPDGeometry
     if isinstance(geom, AGIPDGeometry):

--- a/geoAssembler/gui_utils.py
+++ b/geoAssembler/gui_utils.py
@@ -1,9 +1,6 @@
-
 """Provide helper methods for the gui."""
 
-from collections import namedtuple
 import os
-
 
 from pyqtgraph.Qt import (QtCore, QtGui)
 from .defaults import DefaultGeometryConfig as Defaults

--- a/geoAssembler/main.py
+++ b/geoAssembler/main.py
@@ -83,6 +83,7 @@ def create_calibrate_gui(*args, **kwargs):
     """Create a QtGui Application and return an instance of CalibrateQt."""
     app = QtGui.QApplication([])
     calib = QtMainWidget(app, *args, **kwargs)
+    logging.getLogger().addHandler(calib.log_capturer)
     #calib.show()
     app.exec_()
     app.closeAllWindows()

--- a/geoAssembler/tests/conftest.py
+++ b/geoAssembler/tests/conftest.py
@@ -71,6 +71,6 @@ def calib(gui_app):
     """Create the calibration gui"""
     from ..widgets.pyqt import QtMainWidget
 
-    main_gui = QtMainWidget(gui_app, log_to_window=False)
+    main_gui = QtMainWidget(gui_app)
     yield main_gui
     main_gui.close()

--- a/geoAssembler/tests/test_panelview.py
+++ b/geoAssembler/tests/test_panelview.py
@@ -11,8 +11,7 @@ from ..widgets.pyqt import QtMainWidget
 def test_defaults(mock_dialog, mock_run, gui_app):
     """Test default settings."""
     # Click add circle btn when no image is selected, check for circles
-    test_calib = QtMainWidget(gui_app, mock_run, geofile=None, levels=[0, 1500],
-                              log_to_window=False)
+    test_calib = QtMainWidget(gui_app, mock_run, geofile=None, levels=[0, 1500])
     QTest.mouseClick(test_calib.fit_widget.bt_add_shape, QtCore.Qt.LeftButton)
     assert len(test_calib.shapes) == 0
     # Click the add image button in test mode and check if a run-dir

--- a/geoAssembler/widgets/pyqt.py
+++ b/geoAssembler/widgets/pyqt.py
@@ -233,10 +233,9 @@ class QtMainWidget(QtGui.QMainWindow):
 
     def _draw_rect(self, quad):
         """Draw rectangle around quadrant."""
-        try:
+        if self.rect is not None:
             self.imv.getView().removeItem(self.rect)
-        except AttributeError:
-            pass
+
         if quad is None:
             return
         self.quad = quad

--- a/geoAssembler/widgets/pyqt.py
+++ b/geoAssembler/widgets/pyqt.py
@@ -1,5 +1,4 @@
 """Qt Version of the detector geometry calibration."""
-
 import logging
 
 import numpy as np
@@ -8,7 +7,7 @@ from pyqtgraph.graphicsItems.GradientEditorItem import Gradients
 from pyqtgraph.Qt import QtCore, QtGui
 
 from .qt_subwidgets import GeometryWidget, RunDataWidget, FitObjectWidget
-from .qt_objects import QLogger, warning
+from .qt_objects import LogCapturer, LogDialog, warning
 
 from ..defaults import DefaultGeometryConfig as Defaults
 from ..gui_utils import get_icon
@@ -20,8 +19,7 @@ class QtMainWidget(QtGui.QMainWindow):
     log = logging.getLogger(__name__)
     log.setLevel(logging.DEBUG)
 
-    def __init__(self, app, run_dir=None, geofile=None, levels=None,
-                 log_to_window=True):
+    def __init__(self, app, run_dir=None, geofile=None, levels=None):
         """Display detector data and arrange panels.
 
         Parameters:
@@ -34,10 +32,6 @@ class QtMainWidget(QtGui.QMainWindow):
 
             levels : (tuple)
             min/max values to be displayed (default: -1000)
-
-            log_to_window : (bool)
-            If true, direct Python logging into a dialog for the user.
-
         """
         super().__init__()
 
@@ -56,9 +50,9 @@ class QtMainWidget(QtGui.QMainWindow):
         self.rect = None
         self.quad = -1  # The selected quadrants (-1 none selected)
         self.is_displayed = False
-        q_logger = QLogger(self)
-        if log_to_window:
-            self.log.addHandler(q_logger)
+
+        # This is hooked up to the Python logging system outside the class
+        self.log_capturer = LogCapturer(self)
 
         # Create new image view
         self.imv = pg.ImageView()
@@ -85,7 +79,7 @@ class QtMainWidget(QtGui.QMainWindow):
         self.fit_widget.draw_shape_signal.connect(self._draw_shape)
         self.fit_widget.delete_shape_signal.connect(self._clear_shape)
         self.fit_widget.quit_signal.connect(app.quit)
-        self.fit_widget.show_log_signal.connect(q_logger.show)
+        self.fit_widget.show_log_signal.connect(self.show_log)
         main_widget = QtGui.QWidget(self)
         self.setCentralWidget(main_widget)
 
@@ -299,3 +293,7 @@ class QtMainWidget(QtGui.QMainWindow):
 
     def _move_left(self):
         self._move('l')
+
+    @QtCore.Slot()
+    def show_log(self):
+        LogDialog(self).open()

--- a/geoAssembler/widgets/pyqt.py
+++ b/geoAssembler/widgets/pyqt.py
@@ -24,14 +24,13 @@ class QtMainWidget(QtGui.QMainWindow):
 
         Parameters:
             run_dir : (str)
-            Directory that contains the run data
+              Directory that contains the run data
 
             geofile : (str)
-            The geometry that holding the geometric information on detector
-            assembeling
+              The detector geometry file (CrystFEL or XFEL format)
 
             levels : (tuple)
-            min/max values to be displayed (default: -1000)
+              min/max values to be displayed (default: -1000)
         """
         super().__init__()
 

--- a/geoAssembler/widgets/pyqt.py
+++ b/geoAssembler/widgets/pyqt.py
@@ -1,12 +1,9 @@
 """Qt Version of the detector geometry calibration."""
 
 import logging
-from os import path as op
 
 import numpy as np
 import pyqtgraph as pg
-from PyQt5 import uic
-from PyQt5.QtWidgets import QHBoxLayout
 from pyqtgraph.graphicsItems.GradientEditorItem import Gradients
 from pyqtgraph.Qt import QtCore, QtGui
 
@@ -14,10 +11,7 @@ from .qt_subwidgets import GeometryWidget, RunDataWidget, FitObjectWidget
 from .qt_objects import QLogger, warning
 
 from ..defaults import DefaultGeometryConfig as Defaults
-from ..gui_utils import create_button, get_icon
-
-
-Slot = QtCore.pyqtSlot
+from ..gui_utils import get_icon
 
 
 class QtMainWidget(QtGui.QMainWindow):

--- a/geoAssembler/widgets/qt_objects.py
+++ b/geoAssembler/widgets/qt_objects.py
@@ -29,7 +29,7 @@ class CircleShape(pg.EllipseROI):
         """Create a circular region of interest.
 
         Parameters:
-           pos (int) : centre of the circle
+           pos (tuple) : centre of the circle (x, y)
            size (int) : diameter of the circle
         """
         pen = QtGui.QPen(QtCore.Qt.red, 0.002)
@@ -56,7 +56,7 @@ class SquareShape(pg.RectROI):
         """Create a squared region of interest.
 
         Parameters:
-           pos (int) : centre of the circle
+           pos (tuple) : centre of the circle (x, y)
            size (int) : diameter of the circle
         """
         pen = QtGui.QPen(QtCore.Qt.red, 0.002)

--- a/geoAssembler/widgets/qt_objects.py
+++ b/geoAssembler/widgets/qt_objects.py
@@ -184,6 +184,7 @@ class LogDialog(QtGui.QDialog):
     def __init__(self, main_window):
         super().__init__(parent=main_window)
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+        self.setWindowTitle('GeoAssembler Logs')
         self.log_capturer = main_window.log_capturer
 
         self.text_area = QtGui.QPlainTextEdit(self)

--- a/geoAssembler/widgets/qt_subwidgets.py
+++ b/geoAssembler/widgets/qt_subwidgets.py
@@ -8,13 +8,12 @@ from os import path as op
 import karabo_data as kd
 import numpy as np
 from PyQt5 import uic
-from PyQt5.QtCore import pyqtSlot
 from pyqtgraph.Qt import (QtCore, QtGui, QtWidgets)
 
 from .qt_objects import (CircleShape, DetectorHelper, SquareShape, warning)
 
 from ..defaults import DefaultGeometryConfig as Defaults
-from ..gui_utils import (create_button, get_icon,
+from ..gui_utils import (get_icon,
                          read_geometry, write_geometry)
 
 
@@ -379,7 +378,7 @@ class GeometryWidget(QtWidgets.QFrame):
             self.main_widget.log.info(txt)
             warning(txt, title='Info')
 
-    @pyqtSlot()
+    @Slot()
     def _set_geom(self):
         """Put the geometry file name into the text box."""
         self.le_geometry_file.setText(self._geom_window.filename)


### PR DESCRIPTION
To get the tests working on CI (#2), I added a `log_to_window` flag to disable the log capture in the tests. This was a rather quick and dirty fix. I also noticed that if a lot of logging was produced, the log capture would probably gobble up memory as it added every message to an invisible QPlainTextEdit.

This refactors the relevant code. The QLogger class is split up into `LogCapturer`, which hangs around all the time to store the last 500 messages, and LogDialog, which is created on demand when you click the 'Show log' button. The log capturer is not connected by the tests, so we don't have to worry about disconnecting it when closing the window.

I also did various other cleanups, like removing unused imports, based on warnings in Pycharm.