### PR TITLE
Fix numeric check in test_move_quad

### DIFF
--- a/geoAssembler/tests/test_geometry.py
+++ b/geoAssembler/tests/test_geometry.py
@@ -66,9 +66,8 @@ def test_move_quad():
     geom.move_quad(1, np.array((-1,0)))
     geom.move_quad(1, np.array((0,1)))
 
-    asic = geom.modules[0][0]
-    corners_after = asic.corner_pos
-    assert np.all(corners_before - corners_after == np.zeros(3, dtype='i'))
+    np.testing.assert_allclose(geom.modules[0][0].corner_pos,
+                               corners_before)
 
 def get_quad_corners():
     """The the mothod returning the quadrant corners."""


### PR DESCRIPTION
Tests were failing on a floating point error issue, a difference of about 3e-17. I think we can safely ignore that using `assert_allclose`.