### PR TITLE
Pyqt fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ build/
 dist/
 !geoAssembler/tests/test.geom
 geoAssembler.egg-info/
+.venv/
+.venv
+.vscode/
+pyrightconfig.json

--- a/geoAssembler/__init__.py
+++ b/geoAssembler/__init__.py
@@ -37,10 +37,9 @@ Author: bergeman
 """
 
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 
 from .widgets.notebook import MainWidget as CalibrateNb
 from .widgets.pyqt import QtMainWidget
 from .calibrants import calibrants
-

--- a/geoAssembler/widgets/pyqt.py
+++ b/geoAssembler/widgets/pyqt.py
@@ -138,7 +138,7 @@ class QtMainWidget(QtGui.QMainWindow):
         """Get the karabo data geometry object."""
         return self.geom_selector.get_geom()
 
-    @QtCore.Slot()
+    @QtCore.pyqtSlot()
     def draw_reset_levels(self):
         """Reset the image low/high levels to their initial values"""
         level_low, level_high = self.initial_levels
@@ -147,7 +147,7 @@ class QtMainWidget(QtGui.QMainWindow):
         self.imv.setHistogramRange(min(level_low, 0), level_high * 2)
         self.imv.autoRange()
 
-    @QtCore.Slot()
+    @QtCore.pyqtSlot()
     def assemble_draw(self):
         """Read the geometry file and position all modules."""
         if self.run_dir is None:
@@ -196,7 +196,7 @@ class QtMainWidget(QtGui.QMainWindow):
     def _flip_lr(self):
         return -1 if self.frontview else 1
 
-    @QtCore.Slot(int)
+    @QtCore.pyqtSlot(int)
     def front_view_changed(self, new_state):
         self.frontview = (new_state == QtCore.Qt.Checked)
         self.redraw_image()

--- a/geoAssembler/widgets/qt_subwidgets.py
+++ b/geoAssembler/widgets/qt_subwidgets.py
@@ -97,9 +97,9 @@ class FitObjectWidget(QtWidgets.QFrame):
         """Add a new shape selection to the combo-box."""
         self.cb_shape_number.addItem(repr(self.shapes[self.current_shape]))
         for i in range(self.cb_shape_number.count()):
-            # TODO: this seems to be a bug in QT. If only the last item is 
+            # TODO: this seems to be a bug in QT. If only the last item is
             # activated all the others will get the same label.
-            # Activate all to avoid that behavior 
+            # Activate all to avoid that behavior
             self.cb_shape_number.setCurrentIndex(i)
         self.cb_shape_number.setEnabled(True)
         self.bt_clear_shape.setEnabled(True)
@@ -215,7 +215,7 @@ class RunDataWidget(QtWidgets.QFrame):
 
         self.run_changed.emit()
 
-    @QtCore.Slot()
+    @QtCore.pyqtSlot()
     def _set_sel_method(self):
         select_pulse = False
         if self.rb_mean.isChecked():
@@ -230,7 +230,7 @@ class RunDataWidget(QtWidgets.QFrame):
         self.sb_pulse_id.setEnabled(select_pulse)
         self.selection_changed.emit()
 
-    @QtCore.Slot()
+    @QtCore.pyqtSlot()
     def _sel_run(self):
         """Select a run directory."""
         rfolder = QtGui.QFileDialog.getExistingDirectory(self,

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,8 @@ setup(name="geoAssembler",
           'pyqtgraph',
           'ipywidgets',
           'pyFai',
-          'PyQt5',
-          'PyQt5-sip',
+          'PyQt5 >= 5.13.2',
+          'PyQt5-sip >= 12.7.0',
           'scipy'
 
       ],

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,8 @@ setup(name="geoAssembler",
           'pyqtgraph',
           'ipywidgets',
           'pyFai',
-          'PyQt5 >= 5.13.2',
-          'PyQt5-sip >= 12.7.0',
+          'PyQt5 >= 5.13.2, <= 6.0.0',
+          'PyQt5-sip >= 12.7.0, <= 13.0.0',
           'scipy'
 
       ],


### PR DESCRIPTION
While working on the centre position optimisation feature I ran into the error:

```python
AttributeError: module 'PyQt5.QtCore' has no attribute 'Slot'
```

Found [this page](https://stackoverflow.com/questions/50459672/attributeerror-module-pyqt5-qtcore-has-no-attribute-slot) which said that the `Slot` was replaced with `pyqtSlot`, so I changed it and everything ran fine afterwards.

I assume this might be due to PyQt updating, so in addition to changing the calls to Slot, I also pinned the versions of PyQt to under the next major release, which should help prevent these kind of deprecation problems.

