### PR TITLE
Remove option to sum over pulses

### DIFF
--- a/geoAssembler/widgets/editor/run_data.ui
+++ b/geoAssembler/widgets/editor/run_data.ui
@@ -92,19 +92,6 @@
       </widget>
      </item>
      <item row="0" column="5">
-      <widget class="QRadioButton" name="rb_sum">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply Sum over all Pulses&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Sum</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="6">
       <widget class="QRadioButton" name="rb_mean">
        <property name="enabled">
         <bool>false</bool>
@@ -117,7 +104,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="7">
+     <item row="0" column="6">
       <widget class="QRadioButton" name="rb_macro">
        <property name="enabled">
         <bool>false</bool>
@@ -127,7 +114,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="8">
+     <item row="0" column="7">
       <widget class="QPushButton" name="bt_define_macro">
        <property name="enabled">
         <bool>false</bool>

--- a/geoAssembler/widgets/qt_subwidgets.py
+++ b/geoAssembler/widgets/qt_subwidgets.py
@@ -184,7 +184,7 @@ class RunDataWidget(QtWidgets.QFrame):
         self.bt_select_run_dir.clicked.connect(self._sel_run)
         self.bt_select_run_dir.setIcon(get_icon('open.png'))
 
-        for radio_btn in (self.rb_pulse, self.rb_sum, self.rb_mean):
+        for radio_btn in (self.rb_pulse, self.rb_mean):
             radio_btn.clicked.connect(self._set_sel_method)
 
         # Apply no selection method (sum, mean) to select self.rb_pulses by default
@@ -210,7 +210,7 @@ class RunDataWidget(QtWidgets.QFrame):
         # Enable spin boxes and radio buttons
         self.sb_train_id.setEnabled(True)
         self.sb_pulse_id.setEnabled(True)
-        for radio_btn in (self.rb_pulse, self.rb_sum, self.rb_mean):
+        for radio_btn in (self.rb_pulse, self.rb_mean):
             radio_btn.setEnabled(True)
 
         self.run_changed.emit()
@@ -220,8 +220,6 @@ class RunDataWidget(QtWidgets.QFrame):
         select_pulse = False
         if self.rb_mean.isChecked():
             self._sel_method = np.nanmean
-        elif self.rb_sum.isChecked():
-            self._sel_method = np.nansum
         else:
             # Single Pulse
             self._sel_method = None


### PR DESCRIPTION
I'm contending that this option is redundant, because sum and mean are the same besides a scaling factor. I think mean is more useful, because it works on the same scale as individual pulses, so you can easily switch between mean and single pulses. So I want to remove the sum option as a small simplification.