### PR TITLE
Fix calculation of quadrant positions for DSSC geometry

### DIFF
--- a/geoAssembler/geometry.py
+++ b/geoAssembler/geometry.py
@@ -317,8 +317,7 @@ class DSSCGeometry(GeometryAssembler):
             mod_grp = f['Q{}/M{}'.format(quad, module)]
             mod_offset = mod_grp['Position'][:]
             tile_offset = mod_grp['T{:02}/Position'.format(asic)][:]
-            cr_pos *= self._px_conv
-        return cr_pos - (mod_offset + tile_offset)
+        return (cr_pos * self.unit) - (mod_offset + tile_offset)
 
 
 

--- a/geoAssembler/geometry.py
+++ b/geoAssembler/geometry.py
@@ -317,7 +317,7 @@ class DSSCGeometry(GeometryAssembler):
             mod_grp = f['Q{}/M{}'.format(quad, module)]
             mod_offset = mod_grp['Position'][:]
             tile_offset = mod_grp['T{:02}/Position'.format(asic)][:]
-        return (cr_pos * self.unit) - (mod_offset + tile_offset)
+        return (cr_pos / self.unit) - (mod_offset + tile_offset)
 
 
 


### PR DESCRIPTION
There was an inconsistency in units - EXtra-geom now uses metres internally rather than pixel units, so this needed updating.

I should get round to moving the quadrant position functionality into EXtra-geom, to avoid these kinds of inconsistencies. But that won't be ready in time for Wednesday.