### PR TITLE
Explicitly close pyqtgraph ImageView when main window closed

### DIFF
--- a/geoAssembler/qt/app.py
+++ b/geoAssembler/qt/app.py
@@ -48,7 +48,6 @@ class QtMainWidget(QtGui.QMainWindow):
 
         # pyqtgraph config
         pg.setConfigOptions(imageAxisOrder='row-major')
-        pg.LabelItem(justify='right')
 
         self.geofile = geofile
         self.initial_levels = levels or [0, 10000]
@@ -63,7 +62,7 @@ class QtMainWidget(QtGui.QMainWindow):
         self.log_capturer = LogCapturer(self)
 
         # Create new image view
-        self.imv = pg.ImageView()
+        self.imv = pg.ImageView(parent=self)
         self.log.info('Creating main window')
         # Circle Points by Quadrant
         for action, keys in ((self._move_left, ('left', 'H')),
@@ -76,7 +75,7 @@ class QtMainWidget(QtGui.QMainWindow):
                 shortcut.activated.connect(action)
 
         # circle manipulation other input dialogs go to the top
-        self.fit_widget = FitObjectWidget(self, None)
+        self.fit_widget = FitObjectWidget(self)
 
         self.geom_selector = GeometryWidget(self, self.geofile)
         self.geom_selector.new_geometry.connect(self.assemble_draw)
@@ -271,7 +270,9 @@ class QtMainWidget(QtGui.QMainWindow):
                                movable=False,
                                removable=False,
                                pen=pen,
-                               invertible=False)
+                               invertible=False,
+                               parent=self.imv,
+                              )
         self.rect.handleSize = 0
         self.imv.getView().addItem(self.rect)
         _ = [self.rect.removeHandle(handle)

--- a/geoAssembler/qt/app.py
+++ b/geoAssembler/qt/app.py
@@ -110,6 +110,11 @@ class QtMainWidget(QtGui.QMainWindow):
         if run_dir:
             self.run_selector.read_rundir(run_dir)
 
+    def close(self):
+        self.imv.close()
+        self.imv = None
+        return super().close()
+
     # Some properties coming up
     @property
     def shapes(self):

--- a/geoAssembler/qt/app.py
+++ b/geoAssembler/qt/app.py
@@ -109,10 +109,10 @@ class QtMainWidget(QtGui.QMainWindow):
         if run_dir:
             self.run_selector.read_rundir(run_dir)
 
-    def close(self):
+    def closeEvent(self, event):
         self.imv.close()
         self.imv = None
-        return super().close()
+        return super().closeEvent(event)
 
     # Some properties coming up
     @property

--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -34,13 +34,13 @@ class FitObjectWidget(QtWidgets.QFrame):
     delete_shape_signal = Signal()
     show_log_signal = Signal()
 
-    def __init__(self, main_widget, parent=None):
+    def __init__(self, main_widget):
         """Add a spin box with a label to set radii.
 
         Parameters:
            main_widget : Parent widget
         """
-        super().__init__(parent)
+        super().__init__(parent=main_widget)
         ui_file = op.join(op.dirname(__file__), 'editor/fit_object.ui')
         uic.loadUi(ui_file, self)
 


### PR DESCRIPTION
This avoids segfaults which @RobertRosca and I were seeing. However, it turned out not to be related to the failures on CI with the latest PyQt5 - that's an issue in Qt itself ([1](http://python.6.x6.nabble.com/ANN-PyQt-v5-15-2-Released-td5284162.html#a5284173), [2](https://bugreports.qt.io/browse/QTBUG-88688)).

I also ensured a couple of objects had parents in Qt, but the important change seems to be overriding the `.close()` method.