### PR TITLE
Fix some warnings from running the tests

### DIFF
--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -208,7 +208,7 @@ class RunDataWidget(QtWidgets.QFrame):
         self.sb_train_id.setMaximum(det.data.train_ids[-1])
         self.sb_train_id.setValue(det.data.train_ids[0])
 
-        self.sb_pulse_id.setMaximum(det.frames_per_train - 1)
+        self.sb_pulse_id.setMaximum(int(det.frames_per_train) - 1)
 
         # Enable spin boxes and radio buttons
         self.sb_train_id.setEnabled(True)

--- a/geoAssembler/tests/test_centre_optimiser.py
+++ b/geoAssembler/tests/test_centre_optimiser.py
@@ -1,7 +1,6 @@
 import geoAssembler.optimiser as centreOptimiser
 import geoAssembler
 
-from extra_data import RunDirectory, stack_detector_data
 from extra_geom import AGIPD_1MGeometry
 
 import numpy as np

--- a/geoAssembler/tests/test_centre_optimiser.py
+++ b/geoAssembler/tests/test_centre_optimiser.py
@@ -31,7 +31,7 @@ def test_integrator():
     assert 827 < misaligned_2dint_r.shape[0] < 837
     assert 952 < misaligned_2dint_a.shape[0] < 962
 
-    misaligned_1dint = np.nanmean(misaligned_2dint, axis=0)[100:-100]
+    misaligned_1dint = np.nanmean(misaligned_2dint[:, 100:-100], axis=0)
 
     brightest_ring_idx = np.where(
         misaligned_1dint == np.max(misaligned_1dint


### PR DESCRIPTION
Tests were producing these warnings:

```
geoAssembler/tests/test_centre_optimiser.py::test_integrator
  /home/takluyver/Code/geoAssembler/geoAssembler/tests/test_centre_optimiser.py:34: RuntimeWarning: Mean of empty slice
    misaligned_1dint = np.nanmean(misaligned_2dint, axis=0)[100:-100]

geoAssembler/tests/test_panelview.py::test_defaults
geoAssembler/tests/test_panelview.py::test_preset
geoAssembler/tests/test_panelview.py::test_load_geo
geoAssembler/tests/test_panelview.py::test_levels
geoAssembler/tests/test_panelview.py::test_circles
geoAssembler/tests/test_panelview.py::test_circle_properties
geoAssembler/tests/test_panelview.py::test_shapes_dropdown
geoAssembler/tests/test_panelview.py::test_save_geo
  /home/takluyver/Code/geoAssembler/geoAssembler/qt/subwidgets.py:211: DeprecationWarning: an integer is required (got type numpy.float64).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
    self.sb_pulse_id.setMaximum(det.frames_per_train - 1)
```