### PR TITLE
GUI: Select run, detector & geometry in dialog before launching main GUI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,3 +23,4 @@ jobs:
           command: xvfb-run venv/bin/pytest -v
           environment:
             QT_DEBUG_PLUGINS: 1
+            MPLBACKED: agg

--- a/geoAssembler/defaults.py
+++ b/geoAssembler/defaults.py
@@ -20,10 +20,11 @@ class DefaultGeometryConfig:
                                 (254.5, -16),
                                 (278.5, 275)],
 
-                        'DSSC': [(-5, 140),
-                                 (-5, -5),
-                                 (130, -5),
-                                 (130, 140)],
+                        # FIXME: these are made up; replace with measurements?
+                        'DSSC': [(-130, 5),
+                                 (-130, -125),
+                                 (5, -125),
+                                 (5, 5),],
                         }
 
     quad_pos_units = {

--- a/geoAssembler/defaults.py
+++ b/geoAssembler/defaults.py
@@ -26,6 +26,12 @@ class DefaultGeometryConfig:
                                  (130, 140)],
                         }
 
+    quad_pos_units = {
+        'AGIPD': 'pixels',
+        'LPD': 'mm',
+        'DSSC': 'mm',
+    }
+
     # Definition of increments (INC) the quadrants should move
     # (u = up, d = down, r = right, l = left is given:
     direction = {'u': (0, INC),

--- a/geoAssembler/geometry.py
+++ b/geoAssembler/geometry.py
@@ -130,19 +130,14 @@ class GeometryAssembler:
         if canvas is None:
             return self.exgeom_obj.position_modules_fast(data)
         else:
-            centre = self.snapped_geom.centre
+            out_shape = data.shape[:-3] + tuple(canvas)
+            if np.issubdtype(data.dtype, np.floating):
+                out = np.full(out_shape, np.nan, dtype=data.dtype)
+            else:
+                out = np.zeros(out_shape, dtype=data.dtype)
+            self.exgeom_obj.position_modules_symmetric(data, out=out)
             cv_centre = (canvas[0]//2, canvas[-1]//2)
-            shift = np.array(centre) - np.array(cv_centre)
-            out = np.full(data.shape[:-3] + canvas, np.nan, dtype=data.dtype)
-        for i, module in enumerate(self.snapped_geom.modules):
-            mod_data = data[..., i, :, :]
-            tiles_data = self.exgeom_obj.split_tiles(mod_data)
-            for j, tile in enumerate(module):
-                tile_data = tiles_data[j]
-                y, x = tile.corner_idx - shift
-                h, w = tile.pixel_dims
-                out[..., y: y + h, x: x + w] = tile.transform(tile_data)
-        return out, cv_centre
+            return out, cv_centre
 
     def write_crystfel_geom(self, filename, *,
                             data_path='/entry_1/instrument_1/detector_1/data',

--- a/geoAssembler/geometry.py
+++ b/geoAssembler/geometry.py
@@ -313,8 +313,11 @@ class LPDGeometry(GeometryAssembler):
                             index=['q{}'.format(i) for i in range(1, 5)])
 
 
-GEOM_MODULES = {'AGIPD': AGIPDGeometry,
-                'LPD': LPDGeometry}
+GEOM_CLASSES = {
+    'AGIPD': AGIPDGeometry,
+    'LPD': LPDGeometry,
+    'DSSC': DSSCGeometry,
+}
 
 
 

--- a/geoAssembler/geometry.py
+++ b/geoAssembler/geometry.py
@@ -3,7 +3,6 @@
 import logging
 import tempfile
 
-import h5py
 from extra_geom import (
     AGIPD_1MGeometry, DSSC_1MGeometry, LPD_1MGeometry,
 )

--- a/geoAssembler/geometry.py
+++ b/geoAssembler/geometry.py
@@ -371,6 +371,13 @@ class LPDGeometry(GeometryAssembler):
         exgeom_obj = LPD_1MGeometry.from_quad_positions(quad_pos)
         return cls(exgeom_obj, None)
 
+    @classmethod
+    def from_crystfel_geom(cls, filename):
+        exgeom_obj = LPD_1MGeometry.from_crystfel_geom(filename)
+        # filename used in .quad_pos is expected to be HDF5, so we don't store
+        # the .geom filename here
+        return cls(exgeom_obj, None)
+
     @property
     def quad_pos(self):
         """Get the quadrant positions from the geometry object."""

--- a/geoAssembler/qt/app.py
+++ b/geoAssembler/qt/app.py
@@ -20,7 +20,6 @@ def run_gui(rundir, *args, **kwargs):
     if start_dialog.exec() == QtGui.QDialog.Rejected:
         return 0
 
-    start_dialog.geometry()
     calib = QtMainWidget(
         app,
         start_dialog.xd_run,
@@ -96,7 +95,6 @@ class QtMainWidget(QtGui.QMainWindow):
         self.geom_selector.new_geometry.connect(self.assemble_draw)
 
         self.run_selector = RunDataWidget(self, xd_run, run_path)
-        # self.run_selector.run_changed.connect(self.draw_reset_levels)
         self.run_selector.selection_changed.connect(self.assemble_draw)
 
         self.fit_widget.draw_shape_signal.connect(self._draw_shape)

--- a/geoAssembler/qt/app.py
+++ b/geoAssembler/qt/app.py
@@ -142,19 +142,9 @@ class QtMainWidget(QtGui.QMainWindow):
         return self.imv.getView()
 
     @property
-    def det(self):
-        """Get the currently selected detector from the geometry widget."""
-        return self.geom_selector.det
-
-    @property
     def run_dir(self):
         """Get the currently set run directory from the run dir widget."""
         return self.run_selector.rundir
-
-    @property
-    def geom_file(self):
-        """Get the current geometry file from the geom selector widget."""
-        return self.geom_selector.geom_file
 
     @QtCore.pyqtSlot()
     def draw_reset_levels(self):

--- a/geoAssembler/qt/app.py
+++ b/geoAssembler/qt/app.py
@@ -1,6 +1,5 @@
 """Qt Version of the detector geometry calibration."""
 import logging
-import os.path as op
 
 import numpy as np
 import pyqtgraph as pg

--- a/geoAssembler/qt/app.py
+++ b/geoAssembler/qt/app.py
@@ -1,22 +1,35 @@
 """Qt Version of the detector geometry calibration."""
 import logging
+import os.path as op
 
 import numpy as np
 import pyqtgraph as pg
 from pyqtgraph.graphicsItems.GradientEditorItem import Gradients
 from pyqtgraph.Qt import QtCore, QtGui
 
-from .subwidgets import GeometryWidget, RunDataWidget, FitObjectWidget
+from .subwidgets import GeometryWidget, RunDataWidget, FitObjectWidget, StartDialog
 from .objects import LogCapturer, LogDialog, warning
 
 from ..defaults import DefaultGeometryConfig as Defaults
 from .utils import get_icon
 
 
-def run_gui(*args, **kwargs):
+def run_gui(rundir, *args, **kwargs):
     """Run the Qt calibration windows in a QtGui application"""
     app = QtGui.QApplication([])
-    calib = QtMainWidget(app, *args, **kwargs)
+    start_dialog = StartDialog(rundir)
+    if start_dialog.exec() == QtGui.QDialog.Rejected:
+        return 0
+
+    start_dialog.geometry()
+    calib = QtMainWidget(
+        app,
+        start_dialog.xd_run,
+        start_dialog.run_path,
+        start_dialog.geometry(),
+        start_dialog.selected_detector_type,
+        **kwargs,
+    )
     logging.getLogger().addHandler(calib.log_capturer)
     app.exec_()
     app.closeAllWindows()
@@ -28,7 +41,7 @@ class QtMainWidget(QtGui.QMainWindow):
     log = logging.getLogger(__name__)
     log.setLevel(logging.DEBUG)
 
-    def __init__(self, app, run_dir=None, geofile=None, levels=None):
+    def __init__(self, app, xd_run, run_path, geom_obj, det_type='AGIPD', levels=None):
         """Display detector data and arrange panels.
 
         Parameters:
@@ -49,7 +62,6 @@ class QtMainWidget(QtGui.QMainWindow):
         # pyqtgraph config
         pg.setConfigOptions(imageAxisOrder='row-major')
 
-        self.geofile = geofile
         self.initial_levels = levels or [0, 10000]
 
         self.raw_data = None
@@ -57,6 +69,10 @@ class QtMainWidget(QtGui.QMainWindow):
         self.rect = None
         self.quad = -1  # The selected quadrants (-1 none selected)
         self.is_displayed = False
+
+        self.geom_obj = geom_obj
+        self.xd_run = xd_run
+        self.det_type = det_type
 
         # This is hooked up to the Python logging system outside the class
         self.log_capturer = LogCapturer(self)
@@ -77,11 +93,11 @@ class QtMainWidget(QtGui.QMainWindow):
         # circle manipulation other input dialogs go to the top
         self.fit_widget = FitObjectWidget(self)
 
-        self.geom_selector = GeometryWidget(self, self.geofile)
+        self.geom_selector = GeometryWidget(self)
         self.geom_selector.new_geometry.connect(self.assemble_draw)
 
-        self.run_selector = RunDataWidget(self)
-        self.run_selector.run_changed.connect(self.draw_reset_levels)
+        self.run_selector = RunDataWidget(self, xd_run, run_path)
+        # self.run_selector.run_changed.connect(self.draw_reset_levels)
         self.run_selector.selection_changed.connect(self.assemble_draw)
 
         self.fit_widget.draw_shape_signal.connect(self._draw_shape)
@@ -105,9 +121,7 @@ class QtMainWidget(QtGui.QMainWindow):
         self.showMaximized()
         self.frontview = False
 
-        # If a run directory was already given, read it
-        if run_dir:
-            self.run_selector.read_rundir(run_dir)
+        self.draw_reset_levels()
 
     def closeEvent(self, event):
         self.imv.close()
@@ -144,11 +158,6 @@ class QtMainWidget(QtGui.QMainWindow):
     def geom_file(self):
         """Get the current geometry file from the geom selector widget."""
         return self.geom_selector.geom_file
-
-    @property
-    def geom_obj(self):
-        """Get the karabo data geometry object."""
-        return self.geom_selector.get_geom()
 
     @QtCore.pyqtSlot()
     def draw_reset_levels(self):
@@ -191,7 +200,6 @@ class QtMainWidget(QtGui.QMainWindow):
         self.imv.getImageItem().mouseClickEvent = self._click
         # Set a custom color map
         self.imv.setColorMap(pg.ColorMap(*zip(*Gradients['grey']['ticks'])))
-        self.geom_selector.activate()
         self.quad = -1
         self.fit_widget.bt_add_shape.setEnabled(True)
 
@@ -271,7 +279,6 @@ class QtMainWidget(QtGui.QMainWindow):
                                removable=False,
                                pen=pen,
                                invertible=False,
-                               parent=self.imv,
                               )
         self.rect.handleSize = 0
         self.imv.getView().addItem(self.rect)

--- a/geoAssembler/qt/editor/geometry_editor.ui
+++ b/geoAssembler/qt/editor/geometry_editor.ui
@@ -25,51 +25,44 @@
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-        <widget class="QPushButton" name="bt_load">
-         <property name="toolTip">
-          <string>Load/Set Detector Geometry</string>
-         </property>
+        <widget class="QLabel" name="label_geom">
          <property name="text">
-          <string>Load</string>
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="bt_quad_pos">
+         <property name="text">
+          <string>Quadrant positions</string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QPushButton" name="bt_save">
          <property name="enabled">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
          <property name="toolTip">
           <string>Save geometry</string>
          </property>
          <property name="text">
-          <string>Save</string>
+          <string>Save (.geom)</string>
          </property>
         </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Detector:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QComboBox" name="cb_detectors">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select Detector&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Geometry File</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="le_geometry_file"/>
        </item>
       </layout>
      </item>

--- a/geoAssembler/qt/editor/load_detector.ui
+++ b/geoAssembler/qt/editor/load_detector.ui
@@ -38,6 +38,9 @@
        <property name="toolTip">
         <string>Quadrant Posistions</string>
        </property>
+       <property name="editTriggers">
+        <set>QAbstractItemView::NoEditTriggers</set>
+       </property>
        <attribute name="horizontalHeaderStretchLastSection">
         <bool>true</bool>
        </attribute>

--- a/geoAssembler/qt/editor/load_detector.ui
+++ b/geoAssembler/qt/editor/load_detector.ui
@@ -17,26 +17,19 @@
    <item>
     <layout class="QGridLayout" name="gridLayout">
      <item row="2" column="0">
-      <widget class="QPushButton" name="bt_ok">
-       <property name="text">
-        <string>Ok</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QPushButton" name="bt_cancel">
-       <property name="text">
-        <string>Cancel</string>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Close</set>
        </property>
       </widget>
      </item>
      <item row="1" column="0" colspan="2">
-      <widget class="QPushButton" name="bt_load_geometry">
+      <widget class="QPushButton" name="bt_copy_csv">
        <property name="toolTip">
         <string>Select a Geometry File</string>
        </property>
        <property name="text">
-        <string>Load Geometry</string>
+        <string>Copy as CSV</string>
        </property>
       </widget>
      </item>
@@ -88,5 +81,22 @@
   </layout>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Form</receiver>
+   <slot>close()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>340</x>
+     <y>224</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>366</x>
+     <y>259</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/geoAssembler/qt/editor/load_detector.ui
+++ b/geoAssembler/qt/editor/load_detector.ui
@@ -16,7 +16,7 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="2" column="0">
+     <item row="3" column="0">
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="standardButtons">
         <set>QDialogButtonBox::Close</set>
@@ -74,6 +74,16 @@
          <string>Quad Y-Pos</string>
         </property>
        </column>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>If you started with geometry loaded from an HDF5 file, these quadrant positions should be used with the same file.</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
     </layout>

--- a/geoAssembler/qt/editor/run_data.ui
+++ b/geoAssembler/qt/editor/run_data.ui
@@ -16,18 +16,21 @@
   <layout class="QHBoxLayout" name="horizontalLayout_3">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QPushButton" name="bt_select_run_dir">
-       <property name="toolTip">
-        <string>Select a Run directory</string>
+     <item row="0" column="7">
+      <widget class="QPushButton" name="bt_define_macro">
+       <property name="enabled">
+        <bool>false</bool>
        </property>
        <property name="text">
-        <string>Select Run Directory</string>
+        <string>Define Macro</string>
        </property>
       </widget>
      </item>
      <item row="0" column="1">
       <widget class="QLineEdit" name="le_run_directory">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="readOnly">
         <bool>true</bool>
        </property>
@@ -53,6 +56,29 @@
         </widget>
        </item>
       </layout>
+     </item>
+     <item row="0" column="5">
+      <widget class="QRadioButton" name="rb_mean">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply Average over all Pulses&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Mean</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="6">
+      <widget class="QRadioButton" name="rb_macro">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>From Macro</string>
+       </property>
+      </widget>
      </item>
      <item row="0" column="3">
       <layout class="QHBoxLayout" name="horizontalLayout">
@@ -91,36 +117,10 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="5">
-      <widget class="QRadioButton" name="rb_mean">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply Average over all Pulses&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_3">
        <property name="text">
-        <string>Mean</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="6">
-      <widget class="QRadioButton" name="rb_macro">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>From Macro</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="7">
-      <widget class="QPushButton" name="bt_define_macro">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Define Macro</string>
+        <string>Data:</string>
        </property>
       </widget>
      </item>

--- a/geoAssembler/qt/editor/start.ui
+++ b/geoAssembler/qt/editor/start.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>514</width>
-    <height>427</height>
+    <height>490</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -28,7 +28,10 @@
        <item>
         <widget class="QLineEdit" name="edit_run_path">
          <property name="enabled">
-          <bool>false</bool>
+          <bool>true</bool>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -152,6 +155,9 @@
           <property name="enabled">
            <bool>false</bool>
           </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
         <item>
@@ -192,6 +198,9 @@
          <widget class="QLineEdit" name="edit_geom_path">
           <property name="enabled">
            <bool>false</bool>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -241,8 +250,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>224</x>
-     <y>399</y>
+     <x>230</x>
+     <y>483</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -257,8 +266,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>292</x>
-     <y>405</y>
+     <x>298</x>
+     <y>483</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
@@ -289,12 +298,28 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>191</x>
-     <y>287</y>
+     <x>219</x>
+     <y>366</y>
     </hint>
     <hint type="destinationlabel">
-     <x>439</x>
-     <y>318</y>
+     <x>500</x>
+     <y>409</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>rb_geom_cfel</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>edit_geom_path</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>114</x>
+     <y>353</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>127</x>
+     <y>396</y>
     </hint>
    </hints>
   </connection>

--- a/geoAssembler/qt/editor/start.ui
+++ b/geoAssembler/qt/editor/start.ui
@@ -53,9 +53,6 @@
        <property name="enabled">
         <bool>false</bool>
        </property>
-       <property name="placeholderText">
-        <string>xyz</string>
-       </property>
       </widget>
      </item>
     </layout>

--- a/geoAssembler/qt/editor/start.ui
+++ b/geoAssembler/qt/editor/start.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Select data &amp; initial geometry</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/geoAssembler/qt/editor/start.ui
+++ b/geoAssembler/qt/editor/start.ui
@@ -139,6 +139,44 @@
        </widget>
       </item>
       <item>
+       <widget class="QLabel" name="label_h5_geom">
+        <property name="text">
+         <string>With HDF5 geometry (optional):</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLineEdit" name="edit_h5_path">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="button_open_h5">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Select</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="button_clear_h5">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Clear</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
        <widget class="QRadioButton" name="rb_geom_cfel">
         <property name="enabled">
          <bool>false</bool>

--- a/geoAssembler/qt/editor/start.ui
+++ b/geoAssembler/qt/editor/start.ui
@@ -143,6 +143,9 @@
       </item>
       <item>
        <widget class="QLabel" name="label_h5_geom">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string>With HDF5 geometry (optional):</string>
         </property>

--- a/geoAssembler/qt/editor/start.ui
+++ b/geoAssembler/qt/editor/start.ui
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>514</width>
+    <height>427</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="1" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Run</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLineEdit" name="edit_run_path">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="button_open_run">
+         <property name="text">
+          <string>Select</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Detector</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="combobox_detectors">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="placeholderText">
+        <string>xyz</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="group_geom_options">
+     <property name="title">
+      <string>Start with</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QRadioButton" name="rb_geom_default">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>&amp;Default geometry</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="rb_geom_quadpos">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Specified &amp;quadrant positions</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QTableWidget" name="tb_quadrants">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>Quadrant Posistions</string>
+        </property>
+        <property name="showDropIndicator" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>false</bool>
+        </property>
+        <attribute name="horizontalHeaderStretchLastSection">
+         <bool>true</bool>
+        </attribute>
+        <attribute name="verticalHeaderStretchLastSection">
+         <bool>true</bool>
+        </attribute>
+        <row>
+         <property name="text">
+          <string>1</string>
+         </property>
+        </row>
+        <row>
+         <property name="text">
+          <string>2</string>
+         </property>
+        </row>
+        <row>
+         <property name="text">
+          <string>3</string>
+         </property>
+        </row>
+        <row>
+         <property name="text">
+          <string>4</string>
+         </property>
+        </row>
+        <column>
+         <property name="text">
+          <string>Quad X-Pos</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Quad Y-Pos</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="rb_geom_cfel">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>&amp;CrystFEL format geometry (.geom)</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLineEdit" name="edit_geom_path">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="button_open_geom">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Select</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_status">
+     <property name="text">
+      <string>Select a run to start</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="dialog_buttons">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Open</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>dialog_buttons</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>224</x>
+     <y>399</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>dialog_buttons</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>292</x>
+     <y>405</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>rb_geom_quadpos</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>tb_quadrants</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>228</x>
+     <y>185</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>295</x>
+     <y>222</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>rb_geom_cfel</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>button_open_geom</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>191</x>
+     <y>287</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>439</x>
+     <y>318</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/geoAssembler/qt/objects.py
+++ b/geoAssembler/qt/objects.py
@@ -97,14 +97,14 @@ class DetectorHelper(QtGui.QDialog):
 
         self.setWindowTitle('{} Geometry'.format(det_type))
 
-        self.quad_pos = quad_pos
+        self.quad_pos = list(quad_pos.itertuples(index=False))
 
         self.populate_table()
         self.bt_copy_csv.clicked.connect(self._copy_csv)
 
     def populate_table(self):
         """Update the Qudrant table."""
-        for n, quad_pos in enumerate(self.quad_pos.itertuples(index=False)):
+        for n, quad_pos in enumerate(self.quad_pos):
             self.tb_quadrants.setItem(
                 n, 0, QtGui.QTableWidgetItem(str(quad_pos[0])))
             self.tb_quadrants.setItem(

--- a/geoAssembler/qt/objects.py
+++ b/geoAssembler/qt/objects.py
@@ -81,7 +81,7 @@ class DetectorHelper(QtGui.QDialog):
 
     filename_set_signal = QtCore.pyqtSignal()
 
-    def __init__(self, det, fname, parent=None):
+    def __init__(self, quad_pos, det_type='AGIPD', parent=None):
         """Create a table element for quad selection and file selection.
 
         Parameters:
@@ -95,68 +95,25 @@ class DetectorHelper(QtGui.QDialog):
         ui_file = op.join(op.dirname(__file__), 'editor/load_detector.ui')
         uic.loadUi(ui_file, self)
 
-        self.setWindowTitle('{} Geometry'.format(det))
+        self.setWindowTitle('{} Geometry'.format(det_type))
 
-        self._det = det
-        self.filename = fname
-        self.quad_pos = None
+        self.quad_pos = quad_pos
 
         self.populate_table()
-
-        self.bt_load_geometry.clicked.connect(self._get_files)
-        self.bt_load_geometry.setIcon(get_icon('file.png'))
-        self.bt_ok.clicked.connect(self._apply)
-        self.bt_ok.setIcon(get_icon('gtk-ok.png'))
-        self.bt_cancel.clicked.connect(self.close)
-        self.bt_cancel.setIcon(get_icon('gtk-cancel.png'))
-
-    def set_detector(self, det):
-        """Sets a new detector"""
-        self._det = det
-        self.quad_pos = None
-        self.populate_table()
-
-    def _get_files(self):
-        """Read the geometry filename of from the dialog."""
-        file_format = Defaults.file_formats[self._det]
-        f_type = '{} file format (*.{})'.format(*file_format)
-        filename, _ = QtGui.QFileDialog.getOpenFileName(self,
-                                                        'Load geometry file',
-                                                        '.',
-                                                        f_type)
-
-        if filename is not None and filename:
-            self.filename = filename
-            #self.filename_set_signal.emit()
+        self.bt_copy_csv.clicked.connect(self._copy_csv)
 
     def populate_table(self):
         """Update the Qudrant table."""
-        quad_pos = self.quad_pos or Defaults.fallback_quad_pos[self._det]
-        for n, quad_pos in enumerate(quad_pos):
+        for n, quad_pos in enumerate(self.quad_pos.itertuples(index=False)):
             self.tb_quadrants.setItem(
                 n, 0, QtGui.QTableWidgetItem(str(quad_pos[0])))
             self.tb_quadrants.setItem(
                 n, 1, QtGui.QTableWidgetItem(str(quad_pos[1])))
         self.tb_quadrants.move(0, 0)
 
-    def _apply(self):
-        """Read quad. pos and update the detectors fallback positions."""
-        quad_pos = [[None, None] for _ in range(self.tb_quadrants.rowCount())]
-        for i, j in product(
-                range(self.tb_quadrants.rowCount()),
-                range(self.tb_quadrants.columnCount())):
-            table_element = self.tb_quadrants.item(i, j)
-            try:
-                quad_pos[i][j] = float(table_element.text())
-            except ValueError:
-                warning('Table Elements must be Float')
-                return
-        if not self.filename and self._det != 'AGIPD':
-            warning('You must Select a Geometry File')
-            return
-        self.quad_pos = quad_pos
-        self.filename_set_signal.emit()
-        self.close()
+    def _copy_csv(self):
+        clipboard = QtGui.QGuiApplication.clipboard()
+        clipboard.setText("\n".join(f"{x},{y}" for (x, y) in self.quad_pos))
 
 
 class LogCapturer(logging.Handler, QtCore.QObject):

--- a/geoAssembler/qt/objects.py
+++ b/geoAssembler/qt/objects.py
@@ -1,6 +1,5 @@
 """Definition of additional qt helper objects."""
 from collections import deque
-from itertools import product
 import logging
 from os import path as op
 
@@ -8,8 +7,7 @@ import pyqtgraph as pg
 from PyQt5 import uic
 from pyqtgraph.Qt import (QtCore, QtGui, QtWidgets)
 
-from ..defaults import DefaultGeometryConfig as Defaults
-from .utils import create_button, get_icon
+from .utils import create_button
 
 
 def warning(txt, title="Warning"):

--- a/geoAssembler/qt/objects.py
+++ b/geoAssembler/qt/objects.py
@@ -77,7 +77,7 @@ class SquareShape(pg.RectROI):
 
 
 class DetectorHelper(QtGui.QDialog):
-    """Setup widgets for quad. positions and geometry file selection."""
+    """Show quadrant positions in a table"""
 
     filename_set_signal = QtCore.pyqtSignal()
 

--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -519,7 +519,6 @@ class GeometryWidget(QtWidgets.QFrame):
         geom_window = DetectorHelper(
             self.geom.quad_pos, self.main_widget.det_type, self
         )
-        geom_window.setWindowTitle('{} Geometry'.format(self.det_type))
         geom_window.show()
 
     def _save_geometry_obj(self):

--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -399,9 +399,6 @@ class RunDataWidget(QtWidgets.QFrame):
         self.rundir = rundir
         self._cached_train_stack = (None, None)  # (tid, data)
 
-        # self.bt_select_run_dir.clicked.connect(self._sel_run)
-        # self.bt_select_run_dir.setIcon(get_icon('open.png'))
-
         for radio_btn in (self.rb_pulse, self.rb_mean):
             radio_btn.clicked.connect(self._set_sel_method)
 

--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -188,6 +188,7 @@ class StartDialog(QtWidgets.QDialog):
         return data_classes_to_names[data_cls]
 
     def _choose_geom_file(self):
+        self.edit_geom_path.clear()
         path, _ = QtGui.QFileDialog.getOpenFileName(
             self, filter="CrystFEL geometry (*.geom)"
         )
@@ -200,6 +201,7 @@ class StartDialog(QtWidgets.QDialog):
             self._have_geometry(False)
             raise
 
+        self.edit_geom_path.setText(path)
         self._geom_from_geom_file = geom
         self._have_geometry(True)
 

--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -516,7 +516,9 @@ class GeometryWidget(QtWidgets.QFrame):
 
     def _show_quadpos(self):
         """Show the quad posistions."""
-        geom_window = DetectorHelper(self.geom.quad_pos, self.det_type, self)
+        geom_window = DetectorHelper(
+            self.geom.quad_pos, self.main_widget.det_type, self
+        )
         geom_window.setWindowTitle('{} Geometry'.format(self.det_type))
         geom_window.show()
 

--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -14,7 +14,7 @@ from .utils import get_icon
 
 from ..defaults import DefaultGeometryConfig as Defaults
 from ..geometry import GEOM_CLASSES
-from ..io_utils import read_geometry, write_geometry
+from ..io_utils import write_geometry
 
 
 Slot = QtCore.pyqtSlot

--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -14,7 +14,6 @@ from .utils import get_icon
 
 from ..defaults import DefaultGeometryConfig as Defaults
 from ..geometry import GEOM_CLASSES
-from ..io_utils import write_geometry
 
 
 Slot = QtCore.pyqtSlot
@@ -541,7 +540,5 @@ class GeometryWidget(QtWidgets.QFrame):
                 os.remove(fname)
             except (FileNotFoundError, PermissionError):
                 pass
-            write_geometry(self.geom, fname, self.main_widget.log)
-            txt = ' Geometry information saved to {}'.format(fname)
-            self.main_widget.log.info(txt)
-            warning(txt, title='Info')
+            self.geom.write_crystfel_geom(fname)
+            self.main_widget.log.info('Geometry information saved to %r', fname)

--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -4,7 +4,7 @@ import os
 from os import path as op
 
 from extra_data import RunDirectory, stack_detector_data
-from extra_data.components import AGIPD1M, LPD1M, DSSC1M
+from extra_data.components import AGIPD1M, LPD1M, DSSC1M, identify_multimod_detectors
 import numpy as np
 from PyQt5 import uic
 from pyqtgraph.Qt import (QtCore, QtGui, QtWidgets)
@@ -13,6 +13,7 @@ from .objects import (CircleShape, DetectorHelper, SquareShape, warning)
 from .utils import get_icon
 
 from ..defaults import DefaultGeometryConfig as Defaults
+from ..geometry import GEOM_CLASSES
 from ..io_utils import read_geometry, write_geometry
 
 
@@ -25,7 +26,165 @@ det_data_classes = {
     'LPD': LPD1M,
     'DSSC': DSSC1M
 }
+data_classes_to_names = {v: k for (k, v) in det_data_classes.items()}
 
+
+class StartDialog(QtWidgets.QDialog):
+    """Dialog to select run data, detector and initial geometry"""
+    run_chosen = Signal(str)
+    run_opened = Signal(str)
+    xd_run = None  # An EXtra-data DataCollection object
+    run_path = None
+    _geom_from_geom_file = None
+
+    def __init__(self, run_path=None):
+        super().__init__()
+        ui_file = op.join(op.dirname(__file__), 'editor/start.ui')
+        uic.loadUi(ui_file, self)
+
+        self.available_detectors = []
+
+        self.button_open_run.clicked.connect(self._choose_run_path)
+        self.combobox_detectors.currentIndexChanged.connect(self._select_detector)
+        self.button_open_geom.clicked.connect(self._choose_geom_file)
+
+        self.rb_geom_default.toggled.connect(self._geom_option_changed)
+        self.rb_geom_quadpos.toggled.connect(self._geom_option_changed)
+        self.rb_geom_cfel.toggled.connect(self._geom_option_changed)
+
+        self.run_opened.connect(self.edit_run_path.setText)
+
+        if run_path:
+            self.load_run(run_path)
+
+    @QtCore.pyqtSlot()
+    def _choose_run_path(self):
+        """Select a run directory."""
+        rfolder = QtGui.QFileDialog.getExistingDirectory(
+            self, 'Select run directory'
+        )
+        if rfolder:
+            self.load_run(rfolder)
+
+    def load_run(self, path):
+        try:
+            self.xd_run = RunDirectory(path)
+        except Exception as e:
+            self.label_status.setText(f"Error opening run: {e}")
+            self.xd_run = None
+            self.run_path = None
+            self.group_geom_options.setEnabled(False)
+            self.dialog_buttons.setEnabled(False)
+            raise
+
+        self.run_path = path
+        self.run_opened.emit(path)
+
+        self.available_detectors = sorted(identify_multimod_detectors(
+            self.xd_run, clses=[AGIPD1M, LPD1M, DSSC1M]
+        ))
+        self.combobox_detectors.clear()
+        self.combobox_detectors.addItems([
+            f'{name} ({cls.__name__})' for (name, cls) in self.available_detectors
+        ])
+        self.combobox_detectors.setEnabled(True)
+        self.combobox_detectors.setCurrentIndex(0)
+        if not self.available_detectors:
+            self.label_status.setText("No recognised detectors in run")
+        else:
+            self.label_status.setText(
+                f"Loaded run with {len(self.available_detectors)} detectors"
+            )
+
+    def _have_detector(self, have=False):
+        self.rb_geom_default.setEnabled(have)
+        self.rb_geom_quadpos.setEnabled(have)
+        self.rb_geom_cfel.setEnabled(have)
+        if have:
+            self.rb_geom_default.setChecked(True)
+        self._have_geometry(have)
+
+    @QtCore.pyqtSlot()
+    def _select_detector(self, index=-1):
+        """Update widgets when detector dropdown changes"""
+        # The signal seems to send index=-1 even when a real selection is made.
+        # Retrieve currentIndex instead:
+        index = self.combobox_detectors.currentIndex()
+        self._have_detector(index != -1)
+
+        cls = self.available_detectors[index][1]
+        det_type = data_classes_to_names[cls]
+        unit = Defaults.quad_pos_units[det_type]
+        self.rb_geom_quadpos.setText(f"Specified quadrant positions ({unit})")
+        self.populate_quadpos_table(Defaults.fallback_quad_pos[det_type])
+
+    def populate_quadpos_table(self, quad_pos):
+        """Fill the Quadrant positions table."""
+        def numeric_table_item(val):
+            # https://stackoverflow.com/a/37623147/434217
+            item = QtGui.QTableWidgetItem()
+            item.setData(QtCore.Qt.EditRole, val)
+            return item
+
+        for n, (quad_x, quad_y) in enumerate(quad_pos):
+            self.tb_quadrants.setItem(n, 0, numeric_table_item(quad_x))
+            self.tb_quadrants.setItem(n, 1, numeric_table_item(quad_y))
+        self.tb_quadrants.move(0, 0)
+
+    def quadpos_from_table(self):
+        return [(
+            self.tb_quadrants.item(i, 0).data(QtCore.Qt.EditRole),
+            self.tb_quadrants.item(i, 1).data(QtCore.Qt.EditRole),
+        ) for i in range(4)]
+
+    @property
+    def selected_detector(self):
+        index = self.combobox_detectors.currentIndex()
+        return self.available_detectors[index]
+
+    @property
+    def selected_detector_type(self):
+        _, data_cls = self.selected_detector
+        return data_classes_to_names[data_cls]
+
+    def _choose_geom_file(self):
+        path = QtGui.QFileDialog.getOpenFileName(
+            self, filter="CrystFEL geometry (*.geom)"
+        )
+        try:
+            geom_cls = GEOM_CLASSES[self.selected_detector_type]
+            geom = geom_cls.from_crystfel_geom(path)
+        except Exception as e:
+            self.label_status.setText(f"Error loading geometry file: {e}")
+            self._geom_from_geom_file = None
+            self._have_geometry(False)
+            raise
+
+        self._geom_from_geom_file = geom
+        self._have_geometry(True)
+
+    def _have_geometry(self, have=False):
+        self.dialog_buttons.setEnabled(have)
+
+    def _geom_option_changed(self, _checked):
+        if self.rb_geom_cfel.isChecked():
+            self._have_geometry(self._geom_from_geom_file is not None)
+        else:
+            self._have_geometry(True)
+
+    def geometry(self):
+        """Make a geometry object from the information in the dialog"""
+        if self.rb_geom_cfel.isChecked():
+            return self._geom_from_geom_file
+        else:
+            det_type = self.selected_detector_type
+            if self.rb_geom_quadpos.isChecked():
+                quadpos = self.quadpos_from_table()
+            else:  # rb_geom_default
+                quadpos = Defaults.fallback_quad_pos[det_type]
+
+            geom_cls = GEOM_CLASSES[det_type]
+            return geom_cls.from_quad_positions(quadpos)
 
 class FitObjectWidget(QtWidgets.QFrame):
     """Define a Hbox containing a Spinbox with a Label."""
@@ -167,10 +326,9 @@ class FitObjectWidget(QtWidgets.QFrame):
 class RunDataWidget(QtWidgets.QFrame):
     """A widget that defines run-directory, trainId and self.rb_pulse selection."""
 
-    run_changed = Signal()
     selection_changed = Signal()
 
-    def __init__(self, main_widget):
+    def __init__(self, main_widget, rundir, run_path):
         """Create a btn for run-dir select and 2 spin boxes for train, self.rb_pulse.
 
         Parameters:
@@ -182,11 +340,11 @@ class RunDataWidget(QtWidgets.QFrame):
         uic.loadUi(ui_file, self)
 
         self.main_widget = main_widget
-        self.rundir = None
+        self.rundir = rundir
         self._cached_train_stack = (None, None)  # (tid, data)
 
-        self.bt_select_run_dir.clicked.connect(self._sel_run)
-        self.bt_select_run_dir.setIcon(get_icon('open.png'))
+        # self.bt_select_run_dir.clicked.connect(self._sel_run)
+        # self.bt_select_run_dir.setIcon(get_icon('open.png'))
 
         for radio_btn in (self.rb_pulse, self.rb_mean):
             radio_btn.clicked.connect(self._set_sel_method)
@@ -198,12 +356,17 @@ class RunDataWidget(QtWidgets.QFrame):
         self.sb_train_id.valueChanged.connect(self.selection_changed.emit)
         self.sb_pulse_id.valueChanged.connect(self.selection_changed.emit)
 
+        if rundir is not None:
+            self.run_loaded()
+        if run_path is not None:
+            self.le_run_directory.setText(run_path)
+
     def get_train_id(self):
         return self.sb_train_id.value()
 
     def run_loaded(self):
         """Update the UI after a run is successfully loaded"""
-        det = det_data_classes[self.main_widget.det](self.rundir, min_modules=9)
+        det = det_data_classes[self.main_widget.det_type](self.rundir, min_modules=9)
         self.sb_train_id.setMinimum(det.data.train_ids[0])
         self.sb_train_id.setMaximum(det.data.train_ids[-1])
         self.sb_train_id.setValue(det.data.train_ids[0])
@@ -216,7 +379,6 @@ class RunDataWidget(QtWidgets.QFrame):
         for radio_btn in (self.rb_pulse, self.rb_mean):
             radio_btn.setEnabled(True)
 
-        self.run_changed.emit()
 
     @QtCore.pyqtSlot()
     def _set_sel_method(self):
@@ -230,30 +392,6 @@ class RunDataWidget(QtWidgets.QFrame):
 
         self.sb_pulse_id.setEnabled(select_pulse)
         self.selection_changed.emit()
-
-    @QtCore.pyqtSlot()
-    def _sel_run(self):
-        """Select a run directory."""
-        rfolder = QtGui.QFileDialog.getExistingDirectory(self,
-                                                         'Select run directory')
-        if rfolder:
-            self.read_rundir(rfolder)
-
-    def read_rundir(self, rfolder):
-        """Read a selected run directory."""
-        self.main_widget.log.info('Opening run directory {}'.format(rfolder))
-        QtGui.QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
-        try:
-            self.rundir = RunDirectory(rfolder)
-        except Exception:
-            QtGui.QApplication.restoreOverrideCursor()
-            self.main_widget.log.info('Could not find HDF5-Files')
-            warning('No HDF5-Files found', title='Info')
-            return
-
-        self.le_run_directory.setText(rfolder)
-        self.run_loaded()
-        QtGui.QApplication.restoreOverrideCursor()
 
     def get_train_stack(self):
         """Get a 4D array representing detector data in a train
@@ -302,49 +440,37 @@ class GeometryWidget(QtWidgets.QFrame):
 
     new_geometry = Signal()
 
-    def __init__(self, main_widget, filename):
+    def __init__(self, main_widget, det_type='AGIPD'):
         """Create nested widgets to select and save geometry files."""
         super().__init__(main_widget)
         ui_file = op.join(op.dirname(__file__), 'editor/geometry_editor.ui')
         uic.loadUi(ui_file, self)
 
         self.main_widget = main_widget
-        self.geom = None
+        self.det_type = det_type
 
-        for det in Defaults.detectors:
-            self.cb_detectors.addItem(det)
-
-        self.cb_detectors.currentIndexChanged.connect(
-            self._update_quadpos)
-        self.cb_detectors.setCurrentIndex(0)
-        self.le_geometry_file.setText(filename)
-        self._geom_window = DetectorHelper(self.det, filename, self)
-        self._geom_window.filename_set_signal.connect(self._set_geom)
-
-        self.bt_load.clicked.connect(self._load)
-        self.bt_load.setIcon(get_icon('file.png'))
+        self.bt_quad_pos.clicked.connect(self._show_quadpos)
         self.bt_save.clicked.connect(self._save_geometry_obj)
         self.bt_save.setIcon(get_icon('save.png'))
 
-    def _update_quadpos(self):
-        """Update the quad posistions."""
-        self._geom_window.set_detector(self.det)
-        self._geom_window.setWindowTitle('{} Geometry'.format(self.det))
+        self.label_geom.setText(f"{det_type} geometry")
 
-    def _load(self):
-        """Open a dialog box to select a file."""
-        self._geom_window.show()
+    @property
+    def geom(self):
+        return self.main_widget.geom_obj
+
+    def _show_quadpos(self):
+        """Show the quad posistions."""
+        geom_window = DetectorHelper(self.geom.quad_pos, self.det_type, self)
+        geom_window.setWindowTitle('{} Geometry'.format(self.det_type))
+        geom_window.show()
 
     def _save_geometry_obj(self):
         """Save the loaded geometry to file."""
-        file_format = Defaults.file_formats[self.det][0]
-        out_format = Defaults.file_formats[self.det][-1]
-        file_type = '{} file format (*.{})'.format(file_format, out_format)
-        fname, _ = QtGui.QFileDialog.getSaveFileName(self,
-                                                     'Save geometry file',
-                                                     'geo_assembled.{}'.format(
-                                                         out_format),
-                                                     file_type)
+        file_type = 'CrystFEL geometry (*.geom)'
+        fname, _ = QtGui.QFileDialog.getSaveFileName(
+            self, 'Save geometry file', f'{self.det_type}.geom', filter=file_type
+        )
         if fname:
             self.main_widget.log.info(' Saving output to {}'.format(fname))
             try:
@@ -355,38 +481,3 @@ class GeometryWidget(QtWidgets.QFrame):
             txt = ' Geometry information saved to {}'.format(fname)
             self.main_widget.log.info(txt)
             warning(txt, title='Info')
-
-    @Slot()
-    def _set_geom(self):
-        """Put the geometry file name into the text box."""
-        self.le_geometry_file.setText(self._geom_window.filename)
-        self.geom = None
-        self.new_geometry.emit()
-
-    @property
-    def geom_file(self):
-        """Return the text of the QLinEdit element."""
-        return self.le_geometry_file.text()
-
-    def activate(self):
-        """Change the content of buttons and QLineEdit elements."""
-        self.bt_save.setEnabled(True)
-
-    @property
-    def det(self):
-        """Set Detector from combobox."""
-        return self.cb_detectors.currentText()
-
-    def _create_gemetry_obj(self):
-        """Create the extra_geom geometry object."""
-        if self.det != 'AGIPD' and not self.geom_file:
-            warning('Click the load button to load a geometry file')
-            return
-        if self.geom is None:
-            quad_pos = self._geom_window.quad_pos
-            self.geom = read_geometry(self.det, self.geom_file, quad_pos)
-
-    def get_geom(self):
-        if self.geom is None:
-            self._create_gemetry_obj()
-        return self.geom

--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -216,11 +216,11 @@ class StartDialog(QtWidgets.QDialog):
                 self.rb_geom_quadpos.isChecked()
                 and self.selected_detector_type != 'AGIPD'
         ):
-            self.button_open_h5.setEnabled(False)
-            self.button_clear_h5.setEnabled(False)
-        else:
             self.button_open_h5.setEnabled(True)
             self.button_clear_h5.setEnabled(True)
+        else:
+            self.button_open_h5.setEnabled(False)
+            self.button_clear_h5.setEnabled(False)
 
     def geometry(self):
         """Make a geometry object from the information in the dialog"""

--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -1,7 +1,7 @@
 """Definitions of all widgets that go into the geoAssembler."""
 
 import os
-from os import path as op
+import os.path as op
 
 from extra_data import RunDirectory, stack_detector_data
 from extra_data.components import AGIPD1M, LPD1M, DSSC1M, identify_multimod_detectors
@@ -9,7 +9,7 @@ import numpy as np
 from PyQt5 import uic
 from pyqtgraph.Qt import (QtCore, QtGui, QtWidgets)
 
-from .objects import (CircleShape, DetectorHelper, SquareShape, warning)
+from .objects import (CircleShape, DetectorHelper, SquareShape)
 from .utils import get_icon
 
 from ..defaults import DefaultGeometryConfig as Defaults

--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -496,20 +496,19 @@ class GeometryWidget(QtWidgets.QFrame):
 
     new_geometry = Signal()
 
-    def __init__(self, main_widget, det_type='AGIPD'):
+    def __init__(self, main_widget):
         """Create nested widgets to select and save geometry files."""
         super().__init__(main_widget)
         ui_file = op.join(op.dirname(__file__), 'editor/geometry_editor.ui')
         uic.loadUi(ui_file, self)
 
         self.main_widget = main_widget
-        self.det_type = det_type
 
         self.bt_quad_pos.clicked.connect(self._show_quadpos)
         self.bt_save.clicked.connect(self._save_geometry_obj)
         self.bt_save.setIcon(get_icon('save.png'))
 
-        self.label_geom.setText(f"{det_type} geometry")
+        self.label_geom.setText(f"{self.main_widget.det_type} geometry")
 
     @property
     def geom(self):
@@ -523,9 +522,10 @@ class GeometryWidget(QtWidgets.QFrame):
 
     def _save_geometry_obj(self):
         """Save the loaded geometry to file."""
-        file_type = 'CrystFEL geometry (*.geom)'
         fname, _ = QtGui.QFileDialog.getSaveFileName(
-            self, 'Save geometry file', f'{self.det_type}.geom', filter=file_type
+            self, 'Save geometry file',
+            f'{self.main_widget.det_type}.geom',
+            filter='CrystFEL geometry (*.geom)'
         )
         if fname:
             self.main_widget.log.info(' Saving output to {}'.format(fname))

--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -191,6 +191,9 @@ class StartDialog(QtWidgets.QDialog):
         path, _ = QtGui.QFileDialog.getOpenFileName(
             self, filter="CrystFEL geometry (*.geom)"
         )
+        if not path:  # File dialog cancelled
+            return
+
         try:
             geom_cls = GEOM_CLASSES[self.selected_detector_type]
             geom = geom_cls.from_crystfel_geom(path)

--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -162,7 +162,7 @@ class StartDialog(QtWidgets.QDialog):
         ) for i in range(4)]
 
     def _choose_h5_file(self):
-        path = QtGui.QFileDialog.getOpenFileName(
+        path, _ = QtGui.QFileDialog.getOpenFileName(
             self, filter="EuXFEL HDF5 geometry (*.h5)"
         )
         if path:
@@ -188,7 +188,7 @@ class StartDialog(QtWidgets.QDialog):
         return data_classes_to_names[data_cls]
 
     def _choose_geom_file(self):
-        path = QtGui.QFileDialog.getOpenFileName(
+        path, _ = QtGui.QFileDialog.getOpenFileName(
             self, filter="CrystFEL geometry (*.geom)"
         )
         try:

--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -220,6 +220,7 @@ class StartDialog(QtWidgets.QDialog):
         )
 
     def _enable_h5_geom(self, enabled):
+        self.label_h5_geom.setEnabled(enabled)
         self.edit_h5_path.setEnabled(enabled)
         self.button_open_h5.setEnabled(enabled)
         self.button_clear_h5.setEnabled(enabled)

--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -506,19 +506,25 @@ class GeometryWidget(QtWidgets.QFrame):
         self.main_widget = main_widget
 
         self.bt_quad_pos.clicked.connect(self._show_quadpos)
+        # CrystFEL format geometry not currently supported for DSSC
+        self.bt_save.setEnabled(self.det_type != 'DSSC')
         self.bt_save.clicked.connect(self._save_geometry_obj)
         self.bt_save.setIcon(get_icon('save.png'))
 
-        self.label_geom.setText(f"{self.main_widget.det_type} geometry")
+        self.label_geom.setText(f"{self.det_type} geometry")
 
     @property
     def geom(self):
         return self.main_widget.geom_obj
 
+    @property
+    def det_type(self):
+        return self.main_widget.det_type
+
     def _show_quadpos(self):
         """Show the quad posistions."""
         geom_window = DetectorHelper(
-            self.geom.quad_pos, self.main_widget.det_type, self
+            self.geom.quad_pos, self.det_type, self
         )
         geom_window.show()
 
@@ -526,7 +532,7 @@ class GeometryWidget(QtWidgets.QFrame):
         """Save the loaded geometry to file."""
         fname, _ = QtGui.QFileDialog.getSaveFileName(
             self, 'Save geometry file',
-            f'{self.main_widget.det_type}.geom',
+            f'{self.det_type}.geom',
             filter='CrystFEL geometry (*.geom)'
         )
         if fname:

--- a/geoAssembler/qt/subwidgets.py
+++ b/geoAssembler/qt/subwidgets.py
@@ -214,15 +214,15 @@ class StartDialog(QtWidgets.QDialog):
         else:
             self._have_geometry(True)
 
-        if (
-                self.rb_geom_quadpos.isChecked()
-                and self.selected_detector_type != 'AGIPD'
-        ):
-            self.button_open_h5.setEnabled(True)
-            self.button_clear_h5.setEnabled(True)
-        else:
-            self.button_open_h5.setEnabled(False)
-            self.button_clear_h5.setEnabled(False)
+        self._enable_h5_geom(
+            self.rb_geom_quadpos.isChecked()
+            and self.selected_detector_type != 'AGIPD'
+        )
+
+    def _enable_h5_geom(self, enabled):
+        self.edit_h5_path.setEnabled(enabled)
+        self.button_open_h5.setEnabled(enabled)
+        self.button_clear_h5.setEnabled(enabled)
 
     def geometry(self):
         """Make a geometry object from the information in the dialog"""

--- a/geoAssembler/tests/conftest.py
+++ b/geoAssembler/tests/conftest.py
@@ -2,6 +2,11 @@ import os.path
 import pytest
 from unittest import mock
 
+from extra_data import RunDirectory
+
+from ..defaults import DefaultGeometryConfig as Defaults
+from ..geometry import AGIPDGeometry
+
 @pytest.fixture(scope='session', autouse=True)
 def gui_app():
     import sys
@@ -20,7 +25,7 @@ def mock_run():
          yield td
 
 @pytest.fixture(scope='module')
-def mock_dialog(mock_run):
+def mock_directory_dialog(mock_run):
     """Create a mock dialog for opening a mock_run."""
     from pyqtgraph import QtGui as QG
 
@@ -63,10 +68,19 @@ def save_geo():
         yield save_geo.name
 
 @pytest.fixture()
-def calib(gui_app):
+def calib(gui_app, mock_run):
     """Create the calibration gui"""
     from geoAssembler.qt.app import QtMainWidget
 
-    main_gui = QtMainWidget(gui_app)
+    xd_run = RunDirectory(mock_run)
+    geom = AGIPDGeometry.from_quad_positions(Defaults.fallback_quad_pos['AGIPD'])
+    main_gui = QtMainWidget(gui_app, xd_run, mock_run, geom, det_type='AGIPD')
     yield main_gui
     main_gui.close()
+
+@pytest.fixture()
+def start_dialog(gui_app):
+    from geoAssembler.qt.subwidgets import StartDialog
+    dlg = StartDialog()
+    yield dlg
+    dlg.close()

--- a/geoAssembler/tests/test_panelview.py
+++ b/geoAssembler/tests/test_panelview.py
@@ -1,76 +1,55 @@
 import os
 
-import numpy as np
 from pyqtgraph import QtCore
 from PyQt5.QtTest import QTest
 
 from ..geometry import AGIPDGeometry
-from geoAssembler.qt.app import QtMainWidget
 
 
-def test_defaults(mock_dialog, gui_app):
+def test_defaults(calib):
     """Test default settings."""
     # Click add circle btn when no image is selected, check for circles
-    test_calib = QtMainWidget(gui_app, levels=[0, 1500])
-    QTest.mouseClick(test_calib.fit_widget.bt_add_shape, QtCore.Qt.LeftButton)
-    assert len(test_calib.shapes) == 0
+    test_calib = calib
+    # QTest.mouseClick(test_calib.fit_widget.bt_add_shape, QtCore.Qt.LeftButton)
+    # assert len(test_calib.shapes) == 0
 
-    # Check that we can select a run directory using the button
-    assert test_calib.run_selector.bt_select_run_dir.isEnabled()
-    with mock_dialog:
-        QTest.mouseClick(test_calib.run_selector.bt_select_run_dir, QtCore.Qt.LeftButton)
     #Test if geometry was correctly applied
     assert isinstance(test_calib.geom_obj, AGIPDGeometry)
     #Test if the preset levels are correct
     levels = tuple(test_calib.imv.getImageItem().levels)
-    assert levels[0] == 0
-    assert levels[1] == 1500
+    assert levels == (0, 10000)
     test_calib.close()
 
-def test_preset(mock_dialog, calib):
+def test_preset(calib):
     """Test pre defined settings."""
-    with mock_dialog:
-        QTest.mouseClick(calib.run_selector.bt_select_run_dir, QtCore.Qt.LeftButton)
     assert calib.run_selector.get_train_id() == 10000
     assert calib.run_selector._sel_method == None
     assert calib.run_selector._read_train == True
 
-def test_load_geo(mock_dialog, mock_open, calib, geomfile):
-    """Test the correct loading fo geometry."""
-    with mock_dialog:
-        QTest.mouseClick(calib.run_selector.bt_select_run_dir, QtCore.Qt.LeftButton)
+def test_load_geo(mock_directory_dialog, mock_open, start_dialog, geomfile):
+    """Test the correct loading of geometry."""
+    with mock_directory_dialog:
+        QTest.mouseClick(start_dialog.button_open_run, QtCore.Qt.LeftButton)
     # Push the geometry load button and load a geo file via mock dialog
-    QTest.mouseClick(calib.geom_selector.bt_load, QtCore.Qt.LeftButton)
+    QTest.mouseClick(start_dialog.rb_geom_cfel, QtCore.Qt.LeftButton)
+    assert start_dialog.button_open_geom.isEnabled()
     with mock_open:
-        QTest.mouseClick(calib.geom_selector._geom_window.bt_load_geometry, QtCore.Qt.LeftButton)
-    QTest.mouseClick(calib.geom_selector._geom_window.bt_ok, QtCore.Qt.LeftButton)
+        QTest.mouseClick(start_dialog.button_open_geom, QtCore.Qt.LeftButton)
     # Check that the geo file was loaded
-    assert calib.geom_file == os.path.abspath(geomfile)
-    assert isinstance(calib.geom_obj, AGIPDGeometry)
+    assert start_dialog.edit_geom_path.text() == os.path.abspath(geomfile)
+    assert isinstance(start_dialog.geometry(), AGIPDGeometry)
 
-def test_levels(mock_dialog, calib):
-    """Test for behavior of default levels."""
-    with mock_dialog:
-        QTest.mouseClick(calib.run_selector.bt_select_run_dir, QtCore.Qt.LeftButton)
-    parent = os.path.dirname(__file__)
-    levels = tuple(calib.imv.getImageItem().levels.astype(np.float32))
-    assert levels[0] == 0
-
-def test_circles(mock_dialog, calib):
+def test_circles(calib):
     """Test adding circles."""
     # Draw image
-    with mock_dialog:
-        QTest.mouseClick(calib.run_selector.bt_select_run_dir, QtCore.Qt.LeftButton)
     QTest.mouseClick(calib.fit_widget.bt_clear_shape, QtCore.Qt.LeftButton)
     # Press the add circle button twice, check for num of circles
     QTest.mouseClick(calib.fit_widget.bt_add_shape, QtCore.Qt.LeftButton)
     QTest.mouseClick(calib.fit_widget.bt_add_shape, QtCore.Qt.LeftButton)
     assert len(calib.shapes) == 2
 
-def test_circle_properties(mock_dialog, calib):
+def test_circle_properties(calib):
     """Test changeing properties of the circles."""
-    with mock_dialog:
-        QTest.mouseClick(calib.run_selector.bt_select_run_dir, QtCore.Qt.LeftButton)
     # Add a circle
     QTest.mouseClick(calib.fit_widget.bt_add_shape, QtCore.Qt.LeftButton)
     # Set the size of the spinbox to 800 and check for circ. radius
@@ -82,20 +61,16 @@ def test_circle_properties(mock_dialog, calib):
     # calib.bottom_buttons[1].click()
     assert calib.current_shape.size()[0] == 690
 
-def test_shapes_dropdown(mock_dialog, calib):
+def test_shapes_dropdown(calib):
     """Test the circle selection buttons on the bottom."""
-    with mock_dialog:
-            QTest.mouseClick(calib.run_selector.bt_select_run_dir, QtCore.Qt.LeftButton)
     QTest.mouseClick(calib.fit_widget.bt_add_shape, QtCore.Qt.LeftButton)
     QTest.mouseClick(calib.fit_widget.bt_add_shape, QtCore.Qt.LeftButton)
     assert calib.fit_widget.cb_shape_number.currentText().startswith('Circle')
     QTest.mouseClick(calib.fit_widget.bt_clear_shape, QtCore.Qt.LeftButton)
     assert calib.fit_widget.cb_shape_number.count() == 0
 
-def test_save_geo(mock_dialog, mock_save, mock_warning, save_geo, calib):
+def test_save_geo(mock_save, mock_warning, save_geo, calib):
     """Test saving the geom file."""
-    with mock_dialog, mock_warning:
-        QTest.mouseClick(calib.run_selector.bt_select_run_dir, QtCore.Qt.LeftButton)
     assert calib.geom_selector.bt_save.isEnabled()
     with mock_save, mock_warning:
         QTest.mouseClick(calib.geom_selector.bt_save, QtCore.Qt.LeftButton)


### PR DESCRIPTION
This is an attempt to make the Qt GUI simpler and more reliable. I think that it's complex partly because there are so many things which can change and which all influence one another: detector type, run, train, pulse selection, different ways to modify the geometry. To combat this, I have separated out selecting the run, detector & initial geometry as a dialog before the main GUI.

This makes the GUI somewhat less flexible - if you want to use a different run or a different starting geometry, you have to close the application and launch it again to select those. I hope that having fewer bugs & easier development is worth it.

While working on this, I have also extended the options for loading/creating geometry:

- All 3 supported detectors (AGIPD-1M, LPD, DSSC) can now be constructed with only quadrant positions and no file (see also https://github.com/European-XFEL/EXtra-geom/pull/89)
- CrystFEL format `.geom` files can be used for LPD (as well as AGIPD)

## Screenshots

![image](https://user-images.githubusercontent.com/327925/128187150-eb89573b-9d6c-4890-a7ab-9447e9a0ffb9.png)

![image](https://user-images.githubusercontent.com/327925/128185013-d8a81028-79c9-404c-a078-cd2e8131a69d.png)
