### PR TITLE
Small fixes to notebook code

### DIFF
--- a/geoAssembler/nb/notebook.py
+++ b/geoAssembler/nb/notebook.py
@@ -151,9 +151,8 @@ class MainWidget:
             raw_data (3d-array)  : Data array, containing detector image
                                    (nmodules, y, x)
         Keywords:
-            geometry : None/extra_geom geometry object
-            The geometry file can either be an AGIPD_1MGeometry object or
-            the filename to the geometry file in CFEL fromat
+            geometry : geoAssembler.geometry.*Geometry object
+              May be None to use default geometry for AGIPD
 
             det : str
             detector to be used (if geometry is None)

--- a/geoAssembler/nb/notebook.py
+++ b/geoAssembler/nb/notebook.py
@@ -1,6 +1,6 @@
 
 """Jupyter Version of the detector geometry calibration."""
-
+from copy import copy
 import logging
 
 import numpy as np
@@ -195,7 +195,7 @@ class MainWidget:
         self.shapes = {}
         self.quad = None
         self.frontview = frontview
-        self.cmap = cm.get_cmap(Defaults.cmaps[0]).copy()
+        self.cmap = copy(cm.get_cmap(Defaults.cmaps[0]))
         try:
             self.cmap.set_bad(self.bg)
         except (ValueError, KeyError):


### PR DESCRIPTION
The docstring about the `geometry` parameter was just plain wrong (leading to user confusion: #31). I'd actually like it to accept the EXtra-geom objects, but for now it may as well match what it actually expects.

The ColorMap.copy() method was added to matplotlib just a few months ago. Using `copy.copy()` works on older versions, including the one on exfel_anaconda.