### PR TITLE
Fix colormap change in widget

### DIFF
--- a/geoAssembler/nb/notebook.py
+++ b/geoAssembler/nb/notebook.py
@@ -307,7 +307,7 @@ class MainWidget:
             return
 
         try:
-            cmap = cm.get_cmap(cmap_val).copy()
+            cmap = copy(cm.get_cmap(cmap_val))
             cmap.set_bad(self.bg)
             self.im.set_cmap(cmap)
         except ValueError:

--- a/geoAssembler/nb/tabs.py
+++ b/geoAssembler/nb/tabs.py
@@ -1,5 +1,6 @@
 """Define the Widget tabs that are using in CalibrateNb."""
 
+from copy import copy
 import os
 import logging
 
@@ -413,7 +414,7 @@ class MaterialTab(widgets.VBox):
         """Do not display the ring structure."""
         if self.img is None:
             return
-        cmp = cm.get_cmap('Reds').copy()
+        cmp = copy(cm.get_cmap('Reds'))
         cmp.set_bad('w', alpha=0)
         cmp.set_under('w', alpha=0)
         self.img.set_visible(False)


### PR DESCRIPTION
Fix the selection of a different colormap when displaying a `Calibrate` object.